### PR TITLE
Add group and lamps as light

### DIFF
--- a/pyinels/const.py
+++ b/pyinels/const.py
@@ -44,6 +44,7 @@ DEVICE_TYPE_DICT = {
     "heating": "heating",
     "heat-control": "therm",
     "lights": "light",
+    "lamps": "light",
     "meter": "meter",
     "on_off": "switch",
     "scenes": "scenes",

--- a/pyinels/device/pyBase.py
+++ b/pyinels/device/pyBase.py
@@ -30,6 +30,11 @@ class pyBase:
         return self._device.id
 
     @property
+    def group(self):
+        """Group of the device."""
+        return self._device.group
+
+    @property
     def up(self):
         """Value of shutter for up."""
         return self._device.value[self._device.up if self._device.up


### PR DESCRIPTION
In my iNels home all lights are actually defined as lamps in IDM.
This fixes the issue where all lights are unavailable when the Home Assistant integration is used.

I also added the suggested room to the entities, this way all my 300+ devices show up correctly in their suggested rooms filled out (coming from IMM).